### PR TITLE
Remove unused Image import from SuccessStoriesSection

### DIFF
--- a/src/app/(main)/(home)/_components/SuccessStoriesSection.tsx
+++ b/src/app/(main)/(home)/_components/SuccessStoriesSection.tsx
@@ -2,7 +2,6 @@
 
 import React from 'react'
 import Blur from '@/components/Blur'
-import Image from 'next/image';
 import BrandBars from '@/components/BrandBars';
 import { Carousel, CarouselContent, CarouselItem, CarouselNext, CarouselPrevious } from '@/components/ui/carousel';
 import useAxios from '@/hooks/useAxios';


### PR DESCRIPTION
Deleted the unused 'next/image' import to clean up the SuccessStoriesSection component.